### PR TITLE
moved including markdown to config file

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,19 @@
 <body>
   <section id="abstract" data-include-format="markdown" data-include="abstract.md"></section>
   <section id="sotd"></section><!-- Wordt automatisch gevuld -->
-  <section data-include-format="markdown" class="informative" data-include="ch01.md"></section>
-  <section data-include-format="markdown" data-include="ch02.md"></section>
-  <!-- Hieronder optionele secties. Worden automatisch gevuld -->
+  <script>
+    let content = "";
+
+    const getClass = function(key) {
+      if (respecConfig.content[key]!==""){return ` class="${respecConfig.content[key]}"`}
+    }
+
+    for (let contentKey in respecConfig.content) {
+      content += `<section data-include-format="markdown" data-include="${contentKey}.md" ${getClass(contentKey)||""}></section>`
+    }
+
+    document.getElementById("sotd").insertAdjacentHTML('afterend', content);
+  </script>
   <section id='conformance'></section>
   <section id='tof'></section>
   <section id="index"></section>

--- a/js/config.js
+++ b/js/config.js
@@ -11,6 +11,7 @@ var respecConfig = {
     // previousPublishVersion: "(none)",
     //  previousPublishDate: "(none)",
     //  previousMaturity: "WV",
+    content: {"ch01": "informative", "ch02": ""},
     editors:
         [
             {


### PR DESCRIPTION
De config file heeft nu een content object.
in het object staat de naam van de markdown file met de class in een key:value pair, zodat je de nogsteeds Css classes toe kan voegen zoals "informative". Wil je er geen toevoegen dan geef je een lege string ""