### PR TITLE
Stop met publiceren van snapshot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    uses: Logius-standaarden/Automatisering/.github/workflows/build.yml@snapshot-in-repo
+    uses: Logius-standaarden/Automatisering/.github/workflows/build.yml@main
   check:
     needs: build
     name: Check


### PR DESCRIPTION
Dit is niet meer nodig met de nieuwe build workflow waarbij de snapshot wordt gepubliceerd d.m.v. bijvoorbeeld GitHub Pages